### PR TITLE
fix: include `Aesthetics_Unbound` theme pair in default theme check

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -13,7 +13,8 @@ const App = () => {
 
   if (
     preferredThemePair !== "Dawn_n_Dusk" &&
-    preferredThemePair !== "Cyber_Tech_01"
+    preferredThemePair !== "Cyber_Tech_01" &&
+    preferredThemePair !== "Aesthetics_Unbound"
   ) {
     localStorage.setItem("preferred-theme-pair", "Dawn_n_Dusk");
   }


### PR DESCRIPTION
### Changes
- Added "Aesthetics_Unbound" to the preferred-theme-pair check in `App.tsx`.

### Proofs
![fix-issue-42-aesthetic-unbound-theme](https://github.com/pinacai/PINAC_Workspace/assets/40066656/d94fe214-0ddf-45a8-bc23-00d4fe79cfcc)

### Issue
Resolves: #42


