### PR TITLE
Add Edit Icon to Profile Image

### DIFF
--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -76,7 +76,7 @@ export const Sidebar: React.FC = () => {
                 />
                 <button
                   className={styles.editButton}
-                  onClick={handleEditButtonClick}
+                  onClick={() => changePage("/profile")}
                 >
                   <FaPencilAlt size={20} color="var(--sidebar-icon-color)" />
                 </button>

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -8,6 +8,7 @@ import styles from "./styles/Sidebar.module.css";
 import { MdGroup } from "react-icons/md";
 import { IoMdChatbubbles, IoMdSettings } from "react-icons/io";
 import { LuHistory } from "react-icons/lu";
+import { FaPencilAlt } from "react-icons/fa";
 import defaultUserIcon from "/icon/user_icon.png";
 
 const BREAKPOINT = 460;
@@ -66,12 +67,20 @@ export const Sidebar: React.FC = () => {
       <div className={styles.upperPart}>
         <nav>
           <ul>
-            <li onClick={() => changePage("/profile")}>
-              <img
-                className={styles.userImage}
-                src={userImageUrl || defaultUserIcon}
-                alt="User"
-              />
+            <li>
+              <div className={styles.profileContainer}>
+                <img
+                  className={styles.userImage}
+                  src={userImageUrl || defaultUserIcon}
+                  alt="User"
+                />
+                <button
+                  className={styles.editButton}
+                  onClick={handleEditButtonClick}
+                >
+                  <FaPencilAlt size={20} color="var(--sidebar-icon-color)" />
+                </button>
+              </div>
             </li>
             <div className={styles.dividerLine} />
             {isChatIconVisible && renderNavItem("/", IoMdChatbubbles)}

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -8,7 +8,6 @@ import styles from "./styles/Sidebar.module.css";
 import { MdGroup } from "react-icons/md";
 import { IoMdChatbubbles, IoMdSettings } from "react-icons/io";
 import { LuHistory } from "react-icons/lu";
-import { FaPencilAlt } from "react-icons/fa";
 import defaultUserIcon from "/icon/user_icon.png";
 
 const BREAKPOINT = 460;
@@ -67,20 +66,12 @@ export const Sidebar: React.FC = () => {
       <div className={styles.upperPart}>
         <nav>
           <ul>
-            <li>
-              <div className={styles.profileContainer}>
-                <img
-                  className={styles.userImage}
-                  src={userImageUrl || defaultUserIcon}
-                  alt="User"
-                />
-                <button
-                  className={styles.editButton}
-                  onClick={() => changePage("/profile")}
-                >
-                  <FaPencilAlt size={20} color="var(--sidebar-icon-color)" />
-                </button>
-              </div>
+            <li onClick={() => changePage("/profile")}>
+              <img
+                className={styles.userImage}
+                src={userImageUrl || defaultUserIcon}
+                alt="User"
+              />
             </li>
             <div className={styles.dividerLine} />
             {isChatIconVisible && renderNavItem("/", IoMdChatbubbles)}

--- a/frontend/components/styles/Sidebar.module.css
+++ b/frontend/components/styles/Sidebar.module.css
@@ -20,43 +20,10 @@
   width: 100%;
 }
 
-.profileContainer {
-  position: relative;
-  width: 100px;
-  height: 100px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
 .userImage {
-  width: 50px;
-  height: 50px;
+  height: 30px;
+  width: 30px;
   border-radius: 50%;
-  object-fit: cover;
-  transition: opacity 0.3s ease;
-}
-
-.editButton {
-  position: absolute;
-  width: 50px;
-  height: 50px;
-  border-radius: 50%;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  background: none;
-  border: none;
-  cursor: pointer;
-  display: none;
-}
-
-.profileContainer:hover .userImage {
-  opacity: 0.5;
-}
-
-.profileContainer:hover .editButton {
-  display: block;
 }
 
 .dividerLine {

--- a/frontend/components/styles/Sidebar.module.css
+++ b/frontend/components/styles/Sidebar.module.css
@@ -26,6 +26,34 @@
   border-radius: 50%;
 }
 
+.profileContainer {
+  position: relative;
+}
+
+.userImage {
+  display: block;
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+}
+
+.editButton {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  transform: translate(50%, 50%);
+  background: white;
+  border: none;
+  border-radius: 50%;
+  padding: 5px;
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+}
+
+.editButton:hover {
+  background: #f0f0f0;
+}
+
 .dividerLine {
   margin: 15px 15px;
   border-bottom: 2px solid grey;

--- a/frontend/components/styles/Sidebar.module.css
+++ b/frontend/components/styles/Sidebar.module.css
@@ -20,38 +20,43 @@
   width: 100%;
 }
 
-.userImage {
-  height: 30px;
-  width: 30px;
-  border-radius: 50%;
-}
-
 .profileContainer {
   position: relative;
+  width: 100px;
+  height: 100px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .userImage {
-  display: block;
-  width: 100px;
-  height: 100px;
+  width: 50px;
+  height: 50px;
   border-radius: 50%;
+  object-fit: cover;
+  transition: opacity 0.3s ease;
 }
 
 .editButton {
   position: absolute;
-  bottom: 0;
-  right: 0;
-  transform: translate(50%, 50%);
-  background: white;
-  border: none;
+  width: 50px;
+  height: 50px;
   border-radius: 50%;
-  padding: 5px;
-  box-shadow: 0 0 5px rgba(0, 0, 0, 0.3);
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: none;
+  border: none;
   cursor: pointer;
+  display: none;
 }
 
-.editButton:hover {
-  background: #f0f0f0;
+.profileContainer:hover .userImage {
+  opacity: 0.5;
+}
+
+.profileContainer:hover .editButton {
+  display: block;
 }
 
 .dividerLine {

--- a/frontend/features/profile/index.tsx
+++ b/frontend/features/profile/index.tsx
@@ -85,7 +85,7 @@ const Profile: React.FC = () => {
         <div className={styles.profileCard}>
           <div>
             {/* ======= profile Image ======= */}
-            <div className={styles.profileCardContainer}>
+            <div className={styles.profileImgContainer}>
               <div
                 className={styles.profileImg}
                 style={{ cursor: "pointer" }}

--- a/frontend/features/profile/index.tsx
+++ b/frontend/features/profile/index.tsx
@@ -5,6 +5,7 @@ import styles from "./styles/index.module.css";
 
 // icons
 import profileImage from "/icon/user_icon.png";
+import { FaPencilAlt } from "react-icons/fa";
 
 const Profile: React.FC = () => {
   const location = useLocation();
@@ -84,18 +85,24 @@ const Profile: React.FC = () => {
         <div className={styles.profileCard}>
           <div>
             {/* ======= profile Image ======= */}
-            <div
-              className={styles.profileImg}
-              onClick={handleImageClick}
-              style={{ cursor: "pointer" }}
-            >
-              {imageUrl ? (
-                <img src={imageUrl} alt="Profile" />
-              ) : (
-                <img src={profileImage} alt="Profile" />
-              )}{" "}
-            </div>
-
+            <div className={styles.profileCardContainer}>
+              <div
+                className={styles.profileImg}
+                style={{ cursor: "pointer" }}
+              >
+                {imageUrl ? (
+                  <img src={imageUrl} alt="Profile" />
+                ) : (
+                  <img src={profileImage} alt="Profile" />
+                )}{" "}
+              </div>
+              <button
+                  className={styles.editButton}
+                  onClick={handleImageClick}
+                >
+                  <FaPencilAlt size={20} color="var(--sidebar-icon-color)" />
+                </button>
+              </div>
             {/* ======= Profile Input Form ======= */}
             <input
               type="file"

--- a/frontend/features/profile/styles/index.module.css
+++ b/frontend/features/profile/styles/index.module.css
@@ -8,7 +8,7 @@
   font-family: "Exo2", "Montserrat", sans-serif;
 }
 
-.profileCardContainer {
+.profileImgContainer {
   position: relative;
   height: 150px;
   width: 150px;
@@ -49,11 +49,11 @@
   display: none;
 }
 
-.profileCardContainer:hover .profileImg {
+.profileImgContainer:hover .profileImg {
   opacity: 0.5;
 }
 
-.profileCardContainer:hover .editButton {
+.profileImgContainer:hover .editButton {
   display: block;
 }
 

--- a/frontend/features/profile/styles/index.module.css
+++ b/frontend/features/profile/styles/index.module.css
@@ -8,6 +8,25 @@
   font-family: "Exo2", "Montserrat", sans-serif;
 }
 
+.profileCard {
+  width: 100%;
+  padding: 50px 20px;
+  display: flex;
+  flex-direction: row-reverse;
+  justify-content: flex-end;
+  align-items: flex-start;
+  overflow-y: auto;
+}
+
+.profileCard::-webkit-scrollbar {
+  width: 10px;
+}
+
+.profileCard::-webkit-scrollbar-thumb {
+  background: #999;
+  border-radius: 50px;
+}
+
 .profileImgContainer {
   position: relative;
   height: 150px;
@@ -55,25 +74,6 @@
 
 .profileImgContainer:hover .editButton {
   display: block;
-}
-
-.profileCard {
-  width: 100%;
-  padding: 50px 20px;
-  display: flex;
-  flex-direction: row-reverse;
-  justify-content: flex-end;
-  align-items: flex-start;
-  overflow-y: auto;
-}
-
-.profileCard::-webkit-scrollbar {
-  width: 10px;
-}
-
-.profileCard::-webkit-scrollbar-thumb {
-  background: #999;
-  border-radius: 50px;
 }
 
 .userDetails {

--- a/frontend/features/profile/styles/index.module.css
+++ b/frontend/features/profile/styles/index.module.css
@@ -10,8 +10,8 @@
 
 .profileCardContainer {
   position: relative;
-  width: 100px;
-  height: 100px;
+  height: 150px;
+  width: 150px;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -37,8 +37,8 @@
 
 .editButton {
   position: absolute;
-  width: 50px;
-  height: 50px;
+  width: 100%;
+  height: 100%;
   border-radius: 50%;
   top: 50%;
   left: 50%;

--- a/frontend/features/profile/styles/index.module.css
+++ b/frontend/features/profile/styles/index.module.css
@@ -8,6 +8,55 @@
   font-family: "Exo2", "Montserrat", sans-serif;
 }
 
+.profileCardContainer {
+  position: relative;
+  width: 100px;
+  height: 100px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.profileImg {
+  height: 150px;
+  width: 150px;
+  margin: 20px 20px 20px 100px;
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transition: opacity 0.3s ease;
+}
+
+.profileImg img {
+  height: 100%;
+  width: 100%;
+  object-fit: fill;
+  border-radius: 50%;
+}
+
+.editButton {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  display: none;
+}
+
+.profileCardContainer:hover .profileImg {
+  opacity: 0.5;
+}
+
+.profileCardContainer:hover .editButton {
+  display: block;
+}
+
 .profileCard {
   width: 100%;
   padding: 50px 20px;
@@ -25,23 +74,6 @@
 .profileCard::-webkit-scrollbar-thumb {
   background: #999;
   border-radius: 50px;
-}
-
-.profileImg {
-  height: 150px;
-  width: 150px;
-  margin: 20px 20px 20px 100px;
-  border-radius: 50%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
-.profileImg img {
-  height: 100%;
-  width: 100%;
-  object-fit: fill;
-  border-radius: 50%;
 }
 
 .userDetails {


### PR DESCRIPTION
## PR Description 📜
Added a pencil icon to the profile image for editing, styled it to be over the image, and updated the click functionality to the edit element. This update enhances user interaction and addresses the issue of missing visual indicators for profile image editing.

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/eecd7543-7b6b-422d-b3f1-38d84af9ba8a)
![image](https://github.com/user-attachments/assets/70cd501a-08d9-4f00-9212-c164614339aa)


## Related Issues
#74: Enhancing profile image edit functionality with a visual indicator.


## Checklist

- [x] I have read CODE OF CONDUCT of this project.
- [x] I have tested these changes locally
- [x] My code follows the project's coding standards
